### PR TITLE
Per-cell loss normalization + several misc. improvements

### DIFF
--- a/multi_training.py
+++ b/multi_training.py
@@ -239,7 +239,8 @@ def main(_):
                 data_loaded = pkl.load(f)
                 v1_ema = tf.Variable(data_loaded['v1_ema'], trainable=False, name='V1_EMA')
         else:
-            v1_ema = tf.Variable(tf.ones(shape=(flags.neurons,)), trainable=False, name='V1_EMA')
+            # 3 Hz is near the average FR of cortex
+            v1_ema = tf.Variable(0.003 * tf.ones(shape=(flags.neurons,)), trainable=False, name='V1_EMA')
 
         # here we need information of the layer mask for the OSI loss
         if flags.osi_loss_method == 'neuropixels_fr':

--- a/multi_training.py
+++ b/multi_training.py
@@ -180,6 +180,12 @@ def main(_):
             checkpoint = tf.train.Checkpoint(optimizer=optimizer, model=model)
             checkpoint.restore(checkpoint_directory).assert_consumed()
             print('Checkpoint restored!')
+        elif flags.restore_from != '' and os.path.exists(flags.restore_from):
+            print(f'Restoring checkpoint from {flags.restore_from} with the restore_from option...')
+            checkpoint_directory = tf.train.latest_checkpoint(flags.restore_from)
+            checkpoint = tf.train.Checkpoint(optimizer=optimizer, model=model)
+            checkpoint.restore(checkpoint_directory).assert_consumed()
+            print('Checkpoint restored!')
         else:
             checkpoint = None
 
@@ -194,7 +200,7 @@ def main(_):
             else:
                 # report how many neurons are selected.
                 print(f"Core mask is set to {core_mask.sum()} neurons.")
-            core_mask = tf.constant(core_mask, dtype=tf.bool)
+                core_mask = tf.constant(core_mask, dtype=tf.bool)
         else:
             core_mask = None
             

--- a/v1_model_utils/callbacks.py
+++ b/v1_model_utils/callbacks.py
@@ -95,6 +95,9 @@ class Callbacks:
         self.best_manager = tf.train.CheckpointManager(
             checkpoint, directory=self.logdir, max_to_keep=1
         )
+        self.latest_manager = tf.train.CheckpointManager(
+            checkpoint, directory=self.logdir + '/latest', max_to_keep=1
+        )
         # Manager for osi/dsi checkpoints 
         self.epoch_manager = tf.train.CheckpointManager(
             checkpoint, directory=self.logdir + '/OSI_DSI_checkpoints', max_to_keep=None
@@ -169,6 +172,10 @@ class Callbacks:
             val_loss_value = metric_values[val_loss_index]
 
         self.plot_losses_curves()
+        
+        # save latest model every 10 epochs
+        if self.epoch % 10 == 0:
+            self.save_latest_model()    
 
         if val_loss_value < self.min_val_loss:
         # if True:
@@ -225,6 +232,12 @@ class Callbacks:
             mem_data = printgpu(verbose=1)
             print(f'    Memory consumption (current - peak): {mem_data[0]:.2f} GB - {mem_data[1]:.2f} GB')
         
+    def save_latest_model(self):
+        try:
+            p = self.latest_manager.save(checkpoint_number=self.epoch)
+            print(f'Latest model saved in {p}\n')    
+        except:
+            print("Saving failed. Maybe next time?")    
 
     def save_best_model(self):
         # self.step_counter.assign_add(1)

--- a/v1_model_utils/callbacks.py
+++ b/v1_model_utils/callbacks.py
@@ -79,11 +79,17 @@ class Callbacks:
             self.epoch_metric_values = {key: [] for key in self.metrics_keys}
         else:
             # Load epoch_metric_values and min_val_loss from the file
-            with open(os.path.join(self.logdir, 'train_end_data.pkl'), 'rb') as f:
-                data_loaded = pkl.load(f)
-            self.epoch_metric_values = data_loaded['epoch_metric_values']
-            self.min_val_loss = data_loaded['min_val_loss']
-            self.no_improve_epochs = data_loaded['no_improve_epochs']
+            try:
+                with open(os.path.join(self.logdir, 'train_end_data.pkl'), 'rb') as f:
+                    data_loaded = pkl.load(f)
+                self.epoch_metric_values = data_loaded['epoch_metric_values']
+                self.min_val_loss = data_loaded['min_val_loss']
+                self.no_improve_epochs = data_loaded['no_improve_epochs']
+            except FileNotFoundError:
+                print('No train_end_data.pkl file found. Initializing...')
+                self.min_val_loss = float('inf')
+                self.no_improve_epochs = 0
+                self.epoch_metric_values = {key: [] for key in self.metrics_keys}
 
         # Manager for the best model
         self.best_manager = tf.train.CheckpointManager(
@@ -466,7 +472,7 @@ class Callbacks:
                     lgn_firing_rates_dict = pkl.load(f)
 
             sim_duration = (2500//self.flags.seq_len + 1) * self.flags.seq_len
-            n_trials_per_angle = 1
+            n_trials_per_angle = 10
             spikes = np.zeros((8, sim_duration, self.flags.neurons), dtype=float)
             DG_angles = np.arange(0, 360, 45)
             for trial_id in range(n_trials_per_angle):

--- a/v1_model_utils/loss_functions.py
+++ b/v1_model_utils/loss_functions.py
@@ -521,6 +521,8 @@ class OrientationSelectivityLoss:
         individual_osi_loss = {}
         # individual_dsi_loss = {}
         # individual_penalization_loss = {}
+        
+        cell_count = 0
 
         for key, value in self._target_osi.items():
             if tf.size(value["ids"]) != 0:

--- a/v1_model_utils/other_v1_utils.py
+++ b/v1_model_utils/other_v1_utils.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(parentDir, "general_utils"))
 import file_management
 
 
-def pop_name_to_cell_type(pop_name):
+def pop_name_to_cell_type(pop_name, ignore_l5e_subtypes=False):
     """convert pop_name in the old format to cell types.
     for example,
     'e4Rorb' -> 'L4 Exc'
@@ -43,7 +43,7 @@ def pop_name_to_cell_type(pop_name):
     elif (class_name == "Vip") or (class_name == "Htr3a"):
         subclass = "VIP"
     else:  # excitatory
-        if layer == "5":
+        if layer == "5" and not ignore_l5e_subtypes:
             subclass = class_name
         else:
             subclass = "Exc"


### PR DESCRIPTION
- Rate and ODSI losses are normalized for each cell, not cell type.
- 'restore_from' option is re-enabled
- v1_ema initial value is set to 3 Hz, not 1000 Hz.
- Treatment for when 'train_end_data.pkl' is not found
- function to save the latest model (for every 10 epochs) even when the loss function is not improving
