### PR TITLE
Adding uniform weight option + handling custom neuropixels file (for loss and plots)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "python.formatting.provider": "none",
+    "python.formatting.provider": "none"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,4 @@
         "editor.defaultFormatter": "ms-python.autopep8"
     },
     "python.formatting.provider": "none",
-    "python.languageServer": "None"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "python.formatting.provider": "none"
+    "python.formatting.provider": "none",
+    "python.languageServer": "None"
 }

--- a/multi_training_single_gpu_split.py
+++ b/multi_training_single_gpu_split.py
@@ -67,7 +67,7 @@ def main(_):
     if logdir == '':
         flag_str = f'v1_{flags.neurons}'
         for name, value in flags.flag_values_dict().items():
-            if value != flags[name].default and name in ['n_input', 'core_only', 'connected_selection', 'random_weights']:
+            if value != flags[name].default and name in ['n_input', 'core_only', 'connected_selection', 'random_weights', 'uniform_weights']:
                 flag_str += f'_{name}_{value}'
         # Define flag string as the second part of results_path
         results_dir = f'{flags.results_dir}/{flag_str}'
@@ -288,12 +288,12 @@ def main(_):
         ### EVOKED RATES REGULARIZERS ###
         rate_core_mask = None if flags.all_neuron_rate_loss else core_mask
         evoked_rate_regularizer = losses.SpikeRateDistributionTarget(network, spontaneous_fr=False, rate_cost=flags.rate_cost, pre_delay=delays[0], post_delay=delays[1], 
-                                                                    data_dir=flags.data_dir, core_mask=rate_core_mask, seed=flags.seed, dtype=tf.float32)
+                                                                    data_dir=flags.data_dir, core_mask=rate_core_mask, seed=flags.seed, dtype=tf.float32, neuropixels_df=flags.neuropixels_df)
         # model.add_loss(lambda: evoked_rate_regularizer(rsnn_layer.output[0][0]))
         
         ### SPONTANEOUS RATES REGULARIZERS ###
         spont_rate_regularizer = losses.SpikeRateDistributionTarget(network, spontaneous_fr=True, rate_cost=flags.rate_cost, pre_delay=delays[0], post_delay=delays[1], 
-                                                                    data_dir=flags.data_dir, core_mask=rate_core_mask, seed=flags.seed, dtype=tf.float32)
+                                                                    data_dir=flags.data_dir, core_mask=rate_core_mask, seed=flags.seed, dtype=tf.float32, neuropixels_df=flags.neuropixels_df)
         # model.add_loss(lambda: spont_rate_regularizer(rsnn_layer.output[0][0]))
         # evoked_rate_regularizer = models.SpikeRateDistributionRegularization(target_firing_rates, flags.rate_cost)
 
@@ -334,7 +334,8 @@ def main(_):
                                                         dtype=tf.float32, core_mask=core_mask,
                                                         method=flags.osi_loss_method,
                                                         subtraction_ratio=flags.osi_loss_subtraction_ratio,
-                                                        layer_info=layer_info)
+                                                        layer_info=layer_info,
+                                                        neuropixels_df=flags.neuropixels_df)
         # placeholder_angle = tf.constant(0, dtype=tf.float32, shape=(per_replica_batch_size, 1))
         # model.add_loss(lambda: OSI_DSI_Loss(rsnn_layer.output[0][0], placeholder_angle, trim=True, normalizer=v1_ema))
         # osi_dsi_loss = OSI_DSI_Loss(rsnn_layer.output[0][0], tf.constant(0, dtype=tf.float32, shape=(1,1)), trim=True) 
@@ -987,6 +988,7 @@ if __name__ == '__main__':
     absl.app.flags.DEFINE_string('ckpt_dir', '', '')
     absl.app.flags.DEFINE_string('osi_loss_method', 'crowd_osi', '')
     absl.app.flags.DEFINE_string('optimizer', 'adam', '')
+    absl.app.flags.DEFINE_string('neuropixels_df', 'v1_OSI_DSI_DF.csv', 'File name of the Neuropixels DataFrame for OSI/DSI analysis.')
 
     absl.app.flags.DEFINE_float('learning_rate', .001, '')
     absl.app.flags.DEFINE_float('rate_cost', 100., '')
@@ -1062,6 +1064,7 @@ if __name__ == '__main__':
     absl.app.flags.DEFINE_boolean("reset_every_step", False, "")
     absl.app.flags.DEFINE_boolean("spontaneous_training", False, "")
     absl.app.flags.DEFINE_boolean('random_weights', False, '')
+    absl.app.flags.DEFINE_boolean('uniform_weights', False, '')
     absl.app.flags.DEFINE_boolean("current_input", False, "")
     absl.app.flags.DEFINE_boolean("gradient_checkpointing", False, "")
 

--- a/multi_training_single_gpu_split.py
+++ b/multi_training_single_gpu_split.py
@@ -988,7 +988,7 @@ if __name__ == '__main__':
     absl.app.flags.DEFINE_string('ckpt_dir', '', '')
     absl.app.flags.DEFINE_string('osi_loss_method', 'crowd_osi', '')
     absl.app.flags.DEFINE_string('optimizer', 'adam', '')
-    absl.app.flags.DEFINE_string('neuropixels_df', 'v1_OSI_DSI_DF.csv', 'File name of the Neuropixels DataFrame for OSI/DSI analysis.')
+    absl.app.flags.DEFINE_string('neuropixels_df', 'Neruopixels_data/v1_OSI_DSI_DF.csv', 'File name of the Neuropixels DataFrame for OSI/DSI analysis.')
 
     absl.app.flags.DEFINE_float('learning_rate', .001, '')
     absl.app.flags.DEFINE_float('rate_cost', 100., '')

--- a/osi_dsi_estimator.py
+++ b/osi_dsi_estimator.py
@@ -506,6 +506,6 @@ if __name__ == '__main__':
 
     absl.app.flags.DEFINE_string("rotation", "ccw", "")
     absl.app.flags.DEFINE_string('ckpt_dir', '', '')
-    absl.app.flags.DEFINE_string('neuropixels_df', 'v1_OSI_DSI_DF.csv', 'File name of the Neuropixels DataFrame for OSI/DSI analysis.')
+    absl.app.flags.DEFINE_string('neuropixels_df', 'Neuropixels_data/v1_OSI_DSI_DF.csv', 'File name of the Neuropixels DataFrame for OSI/DSI analysis.')
 
     absl.app.run(main)

--- a/parallel_training_testing.py
+++ b/parallel_training_testing.py
@@ -86,10 +86,12 @@ parser.add_argument('--bmtk_compat_lgn', default=True, action='store_true')
 parser.add_argument('--reset_every_step', default=False, action='store_true')
 parser.add_argument('--spontaneous_training', default=False, action='store_true')
 parser.add_argument('--random_weights', default=False, action='store_true')
+parser.add_argument('--uniform_weights', default=False, action='store_true')
 parser.add_argument('--gradient_checkpointing', default=True, action='store_true')
 parser.add_argument('--nogradient_checkpointing', dest='gradient_checkpointing', action='store_false')
 
 parser.add_argument('--rotation', default='ccw', type=str)
+parser.add_argument('--neuropixels_df', default='v1_OSI_DSI_DF.csv', type=str, help='File name of the Neuropixels DataFrame for OSI/DSI analysis')
 
 
 def submit_job(command):
@@ -112,7 +114,7 @@ def main():
     # Save the configuration of the model based on the main features
     flag_str = f'v1_{v1_neurons}'
     for name, value in vars(flags).items():
-        if value != parser.get_default(name) and name in ['n_input', 'core_only', 'connected_selection', 'random_weights']:
+        if value != parser.get_default(name) and name in ['n_input', 'core_only', 'connected_selection', 'random_weights', 'uniform_weights']:
             flag_str += f'_{name}_{value}'
 
     # Define flag string as the second part of results_path

--- a/parallel_training_testing.py
+++ b/parallel_training_testing.py
@@ -91,7 +91,7 @@ parser.add_argument('--gradient_checkpointing', default=True, action='store_true
 parser.add_argument('--nogradient_checkpointing', dest='gradient_checkpointing', action='store_false')
 
 parser.add_argument('--rotation', default='ccw', type=str)
-parser.add_argument('--neuropixels_df', default='v1_OSI_DSI_DF.csv', type=str, help='File name of the Neuropixels DataFrame for OSI/DSI analysis')
+parser.add_argument('--neuropixels_df', default='Neuropixels_data/v1_OSI_DSI_DF.csv', type=str, help='File name of the Neuropixels DataFrame for OSI/DSI analysis')
 
 
 def submit_job(command):

--- a/parallel_training_testing_allen.py
+++ b/parallel_training_testing_allen.py
@@ -92,7 +92,7 @@ parser.add_argument('--uniform_weights', default=False, action='store_true')
 parser.add_argument('--gradient_checkpointing', default=False, action='store_true')
 parser.add_argument('--rotation', default='ccw', type=str)
 parser.add_argument('--print_only', default=False, action='store_true', help='Only print the commands without submitting them')
-parser.add_argument('--neuropixels_df', default='v1_OSI_DSI_DF.csv', type=str, help='File name of the Neuropixels DataFrame for OSI/DSI analysis')
+parser.add_argument('--neuropixels_df', default='Neuropixels_data/v1_OSI_DSI_DF.csv', type=str, help='File name of the Neuropixels DataFrame for OSI/DSI analysis')
 
 
 def submit_job(command, print_only=False):

--- a/parallel_training_testing_allen.py
+++ b/parallel_training_testing_allen.py
@@ -88,23 +88,34 @@ parser.add_argument('--bmtk_compat_lgn', default=True, action='store_true')
 parser.add_argument('--reset_every_step', default=False, action='store_true')
 parser.add_argument('--spontaneous_training', default=False, action='store_true')
 parser.add_argument('--random_weights', default=False, action='store_true')
+parser.add_argument('--uniform_weights', default=False, action='store_true')
 parser.add_argument('--gradient_checkpointing', default=False, action='store_true')
 parser.add_argument('--rotation', default='ccw', type=str)
+parser.add_argument('--print_only', default=False, action='store_true', help='Only print the commands without submitting them')
+parser.add_argument('--neuropixels_df', default='v1_OSI_DSI_DF.csv', type=str, help='File name of the Neuropixels DataFrame for OSI/DSI analysis')
 
 
-def submit_job(command):
+def submit_job(command, print_only=False):
     """ 
     Submit a job to the cluster using the command provided.
+    If print_only is True, just print the command without submitting.
     """
-    # print("Trying to run the following command.")
-    # print(command)
+    if print_only:
+        print("\n=== COMMAND ===")
+        print(" ".join(command))
+        # For the wrapped python command, extract it for easier viewing
+        if "--wrap" in command:
+            wrap_index = command.index("--wrap")
+            if wrap_index < len(command) - 1:
+                print("\n=== PYTHON COMMAND ===")
+                print(command[wrap_index + 1])
+        # Return a dummy job ID for print-only mode
+        return "DUMMY_JOB_ID"
+    
+    # Actually submit the job
     result = subprocess.run(command, capture_output=True, text=True)
     job_id = re.search(r'\d+', result.stdout.strip())
-    # print("got this one")
-    # print(result)
-    # print(job_id)
     job_id = job_id.group()
-
     return job_id
 
 def main():                
@@ -117,7 +128,7 @@ def main():
     # Save the configuration of the model based on the main features
     flag_str = f'v1_{v1_neurons}'
     for name, value in vars(flags).items():
-        if value != parser.get_default(name) and name in ['n_input', 'core_only', 'connected_selection', 'random_weights']:
+        if value != parser.get_default(name) and name in ['n_input', 'core_only', 'connected_selection', 'random_weights', 'uniform_weights']:
             flag_str += f'_{name}_{value}'
 
     # Define flag string as the second part of results_path
@@ -168,7 +179,7 @@ def main():
     for name, value in vars(flags).items():
         # if value != parser.get_default(name) and name in ['learning_rate', 'rate_cost', 'voltage_cost', 'osi_cost', 'temporal_f', 'n_input', 'seq_len']:
         # if value != parser.get_default(name):
-        if name not in ['seed']: 
+        if name not in ['seed', 'print_only']: 
             if type(value) == bool and value == False:
                 training_script += f"--no{name} "
                 evaluation_script += f"--no{name} "
@@ -191,7 +202,7 @@ def main():
 
     initial_evaluation_command = initial_evaluation_command + ["--wrap"] + [initial_evaluation_script]
     # initial_evaluation_command = [initial_evaluation_script]
-    eval_job_id = submit_job(initial_evaluation_command)
+    eval_job_id = submit_job(initial_evaluation_command, flags.print_only)
     eval_job_ids.append(eval_job_id)
 
     for i in range(flags.n_runs):
@@ -203,13 +214,13 @@ def main():
             else:
                 new_training_script = training_script + f" --seed {flags.seed + i} --ckpt_dir {logdir} --run_session {i}"
             new_training_command = new_training_command + ["--wrap"] + [new_training_script]
-            job_id = submit_job(new_training_command)
+            job_id = submit_job(new_training_command, flags.print_only)
         else:
             new_training_command = training_commands + ['-d', job_ids[i-1], "-o", f"Out/{sim_name}_{v1_neurons}_train_{i}.out", "-e", f"Error/{sim_name}_{v1_neurons}_train_{i}.err", "-J", f"{sim_name}_train_{i}"]
             # new_training_script = training_script + f"--osi_cost 0.1 --rate_cost 10 --seed {flags.seed + i} --ckpt_dir {logdir} --run_session {i}"
             new_training_script = training_script + f"--seed {flags.seed + i} --ckpt_dir {logdir} --run_session {i}"
             new_training_command = new_training_command + ["--wrap"] + [new_training_script]
-            job_id = submit_job(new_training_command)
+            job_id = submit_job(new_training_command, flags.print_only)
         job_ids.append(job_id)
 
         if flags.n_runs == 1: # the run is a single run, no need to submit evaluation jobs. osi_dsi will be evaluated at the end of training run
@@ -218,18 +229,21 @@ def main():
             new_evaluation_command = evaluation_commands + ['-d', job_id, "-o", f"Out/{sim_name}_{v1_neurons}_test_{i}.out", "-e", f"Error/{sim_name}_{v1_neurons}_test_{i}.err", "-J", f"{sim_name}_test_{i}"]
             new_evaluation_script = evaluation_script + f"--seed {flags.seed + i} --ckpt_dir {logdir} --restore_from 'Intermediate_checkpoints' --run_session {i}"
             new_evaluation_command = new_evaluation_command + ["--wrap"] + [new_evaluation_script]
-            eval_job_id = submit_job(new_evaluation_command)
+            eval_job_id = submit_job(new_evaluation_command, flags.print_only)
             eval_job_ids.append(eval_job_id)
 
     # Final evaluation with the best model
     final_evaluation_command = evaluation_commands + ['-d', job_id, "-o", f"Out/{sim_name}_{v1_neurons}_test_final.out", "-e", f"Error/{sim_name}_{v1_neurons}_test_final.err", "-J", f"{sim_name}_test_final"]
     final_evaluation_script = evaluation_script + f"--seed {flags.seed + i} --ckpt_dir {logdir} --restore_from 'Best_model' --run_session {i}"
     final_evaluation_command = final_evaluation_command + ["--wrap"] + [final_evaluation_script]
-    eval_job_id = submit_job(final_evaluation_command)
+    eval_job_id = submit_job(final_evaluation_command, flags.print_only)
     eval_job_ids.append(eval_job_id)
 
-    print("Submitted training jobs with the following JOBIDs:", job_ids)
-    print("Submitted evaluation jobs with the following JOBIDs:", eval_job_ids)
+    if flags.print_only:
+        print("\n=== COMMANDS WERE ONLY PRINTED, NOT SUBMITTED ===\n")
+    else:
+        print("Submitted training jobs with the following JOBIDs:", job_ids)
+        print("Submitted evaluation jobs with the following JOBIDs:", eval_job_ids)
 
 
 if __name__ == '__main__':

--- a/v1_model_utils/callbacks.py
+++ b/v1_model_utils/callbacks.py
@@ -962,7 +962,8 @@ class OsiDsiCallbacks:
         metrics_analysis = ModelMetricsAnalysis(v1_spikes, DG_angles, self.network, data_dir=self.flags.data_dir,
                                                 drifting_gratings_init=self.pre_delay, drifting_gratings_end=self.pre_delay+self.flags.evoked_duration,
                                                 spontaneous_init=0, spontaneous_end=self.pre_delay,
-                                                core_radius=self.flags.plot_core_radius, df_directory=self.images_dir, save_df=True)
+                                                core_radius=self.flags.plot_core_radius, df_directory=self.images_dir, save_df=True,
+                                                neuropixels_df=self.flags.neuropixels_df)
         # Figure for OSI/DSI boxplots
         metrics_analysis(metrics=["Rate at preferred direction (Hz)", "OSI", "DSI"], directory=boxplots_dir, filename=f'Epoch_{self.current_epoch}')
         # Figure for Average firing rate boxplots
@@ -1456,11 +1457,13 @@ class Callbacks:
         if self.neuropixels_feature == "Evoked rate (Hz)":
             metrics_analysis = ModelMetricsAnalysis(v1_spikes, DG_angles, self.network, data_dir=self.flags.data_dir, 
                                                     drifting_gratings_init=self.pre_delay, drifting_gratings_end=seq_len-self.post_delay,
-                                                    core_radius=self.flags.plot_core_radius, df_directory=self.logdir, save_df=False) 
+                                                    core_radius=self.flags.plot_core_radius, df_directory=self.logdir, save_df=False,
+                                                    neuropixels_df=self.flags.neuropixels_df) 
         elif self.neuropixels_feature == 'Spontaneous rate (Hz)':
             metrics_analysis = ModelMetricsAnalysis(v1_spikes, DG_angles, self.network, data_dir=self.flags.data_dir, 
                                                     spontaneous_init=self.pre_delay, spontaneous_end=seq_len-self.post_delay,
-                                                    core_radius=self.flags.plot_core_radius, df_directory=self.logdir, save_df=False) 
+                                                    core_radius=self.flags.plot_core_radius, df_directory=self.logdir, save_df=False,
+                                                    neuropixels_df=self.flags.neuropixels_df) 
         # Figure for Average firing rate boxplots      
         metrics_analysis(metrics=[self.neuropixels_feature], directory=boxplots_dir, filename=f'Epoch_{self.epoch}')    
                 
@@ -1471,7 +1474,7 @@ class Callbacks:
         os.makedirs(boxplots_dir, exist_ok=True)
         metrics_analysis = ModelMetricsAnalysis(v1_spikes, DG_angles, self.network, data_dir=self.flags.data_dir, 
                                                 spontaneous_init=self.pre_delay, spontaneous_end=seq_len-self.post_delay,
-                                                core_radius=self.flags.plot_core_radius, df_directory=self.logdir, save_df=False) 
+                                                core_radius=self.flags.plot_core_radius, df_directory=self.logdir, save_df=False,
+                                                neuropixels_df=self.flags.neuropixels_df)
         # Figure for Average firing rate boxplots
-        metrics_analysis(metrics=['Spontaneous rate (Hz)'], directory=boxplots_dir, filename=f'Epoch_{self.epoch}')   
-                       
+        metrics_analysis(metrics=['Spontaneous rate (Hz)'], directory=boxplots_dir, filename=f'Epoch_{self.epoch}')

--- a/v1_model_utils/callbacks.py
+++ b/v1_model_utils/callbacks.py
@@ -18,6 +18,7 @@ from v1_model_utils.plotting_utils import InputActivityFigure, PopulationActivit
 from v1_model_utils.model_metrics_analysis import ModelMetricsAnalysis
 from v1_model_utils.model_metrics_analysis import calculate_Firing_Rate, get_borders, draw_borders
 from v1_model_utils.psd_utils import PSDAnalyzer
+import shutil
 
 # Set style parameters for publication quality
 plt.rcParams.update({
@@ -41,7 +42,12 @@ plt.rcParams.update({
 })
 
 sns.set(style="ticks")
-plt.rcParams['text.usetex'] = True
+if shutil.which('latex') is not None:
+    use_tex = True
+else:
+    use_tex = False
+    print("LaTeX not found. Using MathText for rendering.")
+plt.rcParams['text.usetex'] = use_tex
 
 def printgpu(gpu_id=0):
     if tf.config.list_physical_devices('GPU'):

--- a/v1_model_utils/load_sparse.py
+++ b/v1_model_utils/load_sparse.py
@@ -159,7 +159,8 @@ def load_network(
     seed=3000,
     connected_selection=True,
     tensorflow_speed_up=False,
-    random_weights=False):
+    random_weights=False,
+    uniform_weights=False):
 
     rd = np.random.RandomState(seed=seed)
     
@@ -320,6 +321,14 @@ def load_network(
         weights_tf = edge["params"]["weight"][edge_exists].astype(np.float32)
         if random_weights:
             np.random.shuffle(weights_tf)
+        if uniform_weights:
+            pos_weights = weights_tf[weights_tf > 0]
+            neg_weights = weights_tf[weights_tf < 0]
+            avg_pos_weight = np.mean(pos_weights)
+            avg_neg_weight = np.mean(neg_weights)
+            weights_tf[weights_tf > 0] = avg_pos_weight
+            weights_tf[weights_tf < 0] = avg_neg_weight
+
 
         n_new_edge = len(target_tf_ids)
         n_edges += int(n_new_edge)
@@ -691,7 +700,8 @@ def load_v1(flags, n_neurons, flag_str=''):
                         seed=flags.seed,
                         connected_selection=flags.connected_selection,
                         tensorflow_speed_up=False,
-                        random_weights=flags.random_weights
+                        random_weights=flags.random_weights,
+                        uniform_weights=flags.uniform_weights
     )
     print('Load_network: %.2f seconds' % (time() - t0))
 
@@ -765,7 +775,7 @@ def cached_load_v1(flags, n_neurons, flag_str=''):
     network, lgn_input, bkg_input = None, None, None
 
     if flag_str == '':
-        flag_str = f"neurons_{n_neurons}_n_input_{flags.n_input}_s{flags.seed}_c{flags.core_only}_con{flags.connected_selection}_random_weights_{flags.random_weights}"
+        flag_str = f"neurons_{n_neurons}_n_input_{flags.n_input}_s{flags.seed}_c{flags.core_only}_con{flags.connected_selection}_random_weights_{flags.random_weights}_uniform_weights_{flags.uniform_weights}"
     
     file_dir = os.path.split(__file__)[0]
     cache_dir = os.path.join(flags.data_dir, "tf_data")

--- a/v1_model_utils/loss_functions.py
+++ b/v1_model_utils/loss_functions.py
@@ -701,7 +701,8 @@ class CustomMeanLayer(Layer):
 
 class OrientationSelectivityLoss:
     def __init__(self, network=None, osi_cost=1e-5, pre_delay=None, post_delay=None, dtype=tf.float32, 
-                 core_mask=None, method="crowd_osi", subtraction_ratio=1.0, layer_info=None, neuropixels_df="Neuropixels_data/v1_OSI_DSI_DF.csv"):
+                 core_mask=None, method="crowd_osi", subtraction_ratio=1.0, layer_info=None,
+                 neuropixels_df="Neuropixels_data/v1_OSI_DSI_DF.csv"):
         
         self._network = network
         self._osi_cost = osi_cost

--- a/v1_model_utils/loss_functions.py
+++ b/v1_model_utils/loss_functions.py
@@ -394,6 +394,11 @@ def process_neuropixels_data(path=''):
     # return df
 
 def neuropixels_cell_type_to_cell_type(pop_name):
+    if not isinstance(pop_name, str):
+        return pop_name
+    if ' ' in pop_name:  # This is already new. No need to update.
+        return pop_name
+
     # Convert pop_name in the neuropixels cell type to cell types. E.g, 'EXC_L23' -> 'L2/3 Exc', 'PV_L5' -> 'L5 PV'
     layer = pop_name.split('_')[1]
     class_name = pop_name.split('_')[0]
@@ -414,7 +419,8 @@ class SpikeRateDistributionTarget:
         The main difference is that this class will calculate the loss
         for each subtypes of the neurons."""
     def __init__(self, network, spontaneous_fr=False, rate_cost=.5, pre_delay=None, post_delay=None, 
-                 data_dir='GLIF_network', core_mask=None, rates_dampening=1.0, seed=42, dtype=tf.float32):
+                 data_dir='GLIF_network', core_mask=None, rates_dampening=1.0, seed=42, dtype=tf.float32,
+                 neuropixels_df='Neuropixels_data/v1_OSI_DSI_DF.csv'):
         self._network = network
         self._rate_cost = rate_cost
         self._pre_delay = pre_delay
@@ -426,6 +432,7 @@ class SpikeRateDistributionTarget:
         self._data_dir = data_dir
         self._dtype = dtype
         self._seed = seed
+        self._neuropixels_df = neuropixels_df
         if spontaneous_fr:
             self.neuropixels_feature = 'firing_rate_sp'
         else:
@@ -440,33 +447,49 @@ class SpikeRateDistributionTarget:
             dict: Dictionary containing rates and node_type_ids for each population query.
         """
         # Load data
-        neuropixels_data_path = f'Neuropixels_data/v1_OSI_DSI_DF.csv'
-        if not os.path.exists(neuropixels_data_path):
-            process_neuropixels_data(path=neuropixels_data_path)
+        # neuropixels_data_path = f'Neuropixels_data/v1_OSI_DSI_DF.csv'
 
+        neuropixels_data_path = self._neuropixels_df
+        if neuropixels_data_path == 'Neuropixels_data/v1_OSI_DSI_DF.csv':
+            if not os.path.exists(neuropixels_data_path):
+                process_neuropixels_data(path=neuropixels_data_path)
+        else: # just inform the user that the custom file is loading.
+            print(f"Using custom neuropixels data file for FR loss: {neuropixels_data_path}")
+
+        # New dataset has Spont_Rate(Hz) instead of firing_rate_sp.
+        # if reading firing_rate_sp fails, replace it with Spont_Rate(Hz) and try again.
         features_to_load = ['ecephys_unit_id', 'cell_type', 'firing_rate_sp', 'Ave_Rate(Hz)']
-        np_df = pd.read_csv(neuropixels_data_path, index_col=0, sep=" ", usecols=features_to_load).dropna(how='all')
+        try:
+            np_df = pd.read_csv(neuropixels_data_path, index_col=0, sep=" ", usecols=features_to_load).dropna(how='all')
+        except ValueError:
+            print(f"Neuropixels data file {neuropixels_data_path} does not contain firing_rate_sp. Using Spont_Rate(Hz) instead.")
+            features_to_load = ['ecephys_unit_id', 'cell_type', 'Spont_Rate(Hz)', 'Ave_Rate(Hz)']
+            np_df = pd.read_csv(neuropixels_data_path, index_col=0, sep=" ", usecols=features_to_load).dropna(how='all')
+            # Rename the column to match the original
+            np_df.rename(columns={'Spont_Rate(Hz)': 'firing_rate_sp'}, inplace=True)
         area_node_types = pd.read_csv(os.path.join(self._data_dir, f'network/v1_node_types.csv'), sep=" ")
+        # Ensure they use the new names
+        np_df["cell_type"] = np_df["cell_type"].apply(neuropixels_cell_type_to_cell_type)
 
         # Define population queries
         query_mapping = {
-            "i1H": 'ALL_L1',
-            "e23": 'EXC_L23',
-            "i23P": 'PV_L23',
-            "i23S": 'SST_L23',
-            "i23V": 'VIP_L23',
-            "e4": 'EXC_L4',
-            "i4P": 'PV_L4',
-            "i4S": 'SST_L4',
-            "i4V": 'VIP_L4',
-            "e5": 'EXC_L5',
-            "i5P": 'PV_L5',
-            "i5S": 'SST_L5',
-            "i5V": 'VIP_L5',
-            "e6": 'EXC_L6',
-            "i6P": 'PV_L6',
-            "i6S": 'SST_L6',
-            "i6V": 'VIP_L6'
+            "i1H": 'L1 Htr3a',
+            "e23": 'L2/3 Exc',
+            "i23P": 'L2/3 PV',
+            "i23S": 'L2/3 SST',
+            "i23V": 'L2/3 VIP',
+            "e4": 'L4 Exc',
+            "i4P": 'L4 PV',
+            "i4S": 'L4 SST',
+            "i4V": 'L4 VIP',
+            "e5": 'L5 Exc',
+            "i5P": 'L5 PV',
+            "i5S": 'L5 SST',
+            "i5V": 'L5 VIP',
+            "e6": 'L6 Exc',
+            "i6P": 'L6 PV',
+            "i6S": 'L6 SST',
+            "i6V": 'L6 VIP'
         }
 
         # Define the reverse mapping
@@ -678,7 +701,7 @@ class CustomMeanLayer(Layer):
 
 class OrientationSelectivityLoss:
     def __init__(self, network=None, osi_cost=1e-5, pre_delay=None, post_delay=None, dtype=tf.float32, 
-                 core_mask=None, method="crowd_osi", subtraction_ratio=1.0, layer_info=None):
+                 core_mask=None, method="crowd_osi", subtraction_ratio=1.0, layer_info=None, neuropixels_df="Neuropixels_data/v1_OSI_DSI_DF.csv"):
         
         self._network = network
         self._osi_cost = osi_cost
@@ -689,6 +712,7 @@ class OrientationSelectivityLoss:
         self._method = method
         self._subtraction_ratio = subtraction_ratio  # only for crowd_spikes method
         self._tf_pi = tf.constant(np.pi, dtype=dtype)
+        self._neuropixels_df = neuropixels_df
         if (self._core_mask is not None) and (self._method == "crowd_spikes" or self._method == "crowd_osi"):
             self.np_core_mask = self._core_mask.numpy()
             core_tuning_angles = network['tuning_angle'][self.np_core_mask]
@@ -755,9 +779,14 @@ class OrientationSelectivityLoss:
             dict: Dictionary containing rates and node_type_ids for each population query.
         """
         # Load data
-        neuropixels_data_path = f'Neuropixels_data/v1_OSI_DSI_DF.csv'
-        if not os.path.exists(neuropixels_data_path):
-            process_neuropixels_data(path=neuropixels_data_path)
+        # neuropixels_data_path = f'Neuropixels_data/v1_OSI_DSI_DF.csv'
+        neuropixels_data_path = self._neuropixels_df
+        # if the default one is specified and the file doesn't exist, process the data
+        if neuropixels_data_path == "Neuropixels_data/v1_OSI_DSI_DF.csv":
+            if not os.path.exists(neuropixels_data_path):
+                process_neuropixels_data(path=neuropixels_data_path)
+        else:
+            print(f"Using custom neuropixels data file for OSI/DSI loss: {neuropixels_data_path}")
         features_to_load = ['ecephys_unit_id', 'cell_type', 'OSI', 'DSI', "Ave_Rate(Hz)", "max_mean_rate(Hz)"]
         osi_dsi_df = pd.read_csv(neuropixels_data_path, index_col=0, sep=" ", usecols=features_to_load).dropna(how='all')
         
@@ -964,4 +993,4 @@ class OrientationSelectivityLoss:
             return self.crowd_spikes_loss(spikes, angle)
         elif self._method == "neuropixels_fr":
             return self.neuropixels_fr_loss(spikes, angle)
-        
+

--- a/v1_model_utils/model_metrics_analysis.py
+++ b/v1_model_utils/model_metrics_analysis.py
@@ -534,7 +534,7 @@ class MetricsBoxplot:
         self.osi_dsi_dfs.append(self.get_osi_dsi_df(metrics_df, data_source_name="V1 GLIF model", data_dir=self.save_dir))
         # self.osi_dsi_dfs.append(self.get_osi_dsi_df(f"OSI_DSI_neuropixels_v4.csv", data_source_name="Neuropixels", data_dir='Neuropixels_data'))
         # self.osi_dsi_dfs.append(self.get_osi_dsi_df(f"V1_OSI_DSI_DF.csv", data_source_name="Billeh et al (2020)", data_dir='Billeh_column_metrics'))
-        self.osi_dsi_dfs.append(self.get_osi_dsi_df(neurpixels_df, data_source_name="Neuropixels", data_dir='Neuropixels_data'))
+        self.osi_dsi_dfs.append(self.get_osi_dsi_df(neuropixels_df, data_source_name="Neuropixels", data_dir='Neuropixels_data'))
         df = pd.concat(self.osi_dsi_dfs, ignore_index=True)
 
         # Create a figure to compare several model metrics against Neuropixels data

--- a/v1_model_utils/model_metrics_analysis.py
+++ b/v1_model_utils/model_metrics_analysis.py
@@ -20,6 +20,7 @@ from scipy.stats import ks_2samp
 from scipy.stats import f as f_distribution
 from scipy.optimize import curve_fit
 from numba import njit
+import shutil
 
 mpl.style.use('default')
 # rd = np.random.RandomState(seed=42)
@@ -46,7 +47,7 @@ plt.rcParams.update({
 })
 
 sns.set(style="ticks")
-plt.rcParams['text.usetex'] = True
+plt.rcParams['text.usetex'] = shutil.which('latex') is not None
 
 def calculate_Firing_Rate(z, stimulus_init=500, stimulus_end=2500, temporal_axis=2):
     # Select the relevant portion of the data along the temporal axis

--- a/v1_model_utils/plotting_utils.py
+++ b/v1_model_utils/plotting_utils.py
@@ -7,7 +7,7 @@ import pandas as pd
 from matplotlib import patches
 import seaborn as sns
 from . import other_v1_utils, toolkit
-
+import shutil
 
 # Set style parameters for publication quality
 plt.rcParams.update({
@@ -31,7 +31,7 @@ plt.rcParams.update({
 })
 
 sns.set(style="ticks")
-plt.rcParams['text.usetex'] = True
+plt.rcParams['text.usetex'] = shutil.which('latex') is not None
 
 class InputActivityFigure:
     def __init__(

--- a/v1_model_utils/psd_utils.py
+++ b/v1_model_utils/psd_utils.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from statsmodels.stats.multitest import multipletests
 import pandas as pd
 import other_v1_utils
+import shutil
 
 # Set style parameters for publication quality
 plt.rcParams.update({
@@ -32,7 +33,7 @@ plt.rcParams.update({
 })
 
 sns.set(style="ticks")
-plt.rcParams['text.usetex'] = True
+plt.rcParams['text.usetex'] = shutil.which('latex') is not None
 
 
 def compute_band_power(freqs, psd, band):


### PR DESCRIPTION
Two new options are added.

--uniform_weights
(store_true), Make the synaptic weight to a uniform value. Grand average for all the excitatory connections (>0) and inhibitory connections (<0) are calculated and all the values are replaced with either of these two, keeping the original sign.

--neuropixels_df <file path>
One can specify a path to a .csv file that stores the neuropixels statistics.